### PR TITLE
Add required name field to skills frontmatter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ git clone https://github.com/astral-sh/claude-code-plugins
 Add the local marketplace:
 
 ```bash
-/plugin marketplace add ./claude-code-plugins
+/plugin marketplace add ./.claude-plugin/marketplace.json
 ```
 
 Install the plugins:

--- a/plugins/astral/skills/ruff/SKILL.md
+++ b/plugins/astral/skills/ruff/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ruff
 description:
   Guide for using ruff, the extremely fast Python linter and formatter. Use this
   when linting, formatting, or fixing Python code.

--- a/plugins/astral/skills/ruff/SKILL.md
+++ b/plugins/astral/skills/ruff/SKILL.md
@@ -3,6 +3,8 @@ name: ruff
 description:
   Guide for using ruff, the extremely fast Python linter and formatter. Use this
   when linting, formatting, or fixing Python code.
+metadata:
+  author: astral-sh
 ---
 
 # ruff

--- a/plugins/astral/skills/ruff/SKILL.md
+++ b/plugins/astral/skills/ruff/SKILL.md
@@ -5,6 +5,7 @@ description:
   when linting, formatting, or fixing Python code.
 metadata:
   author: astral-sh
+  license: either of Apache-2.0 or MIT
 ---
 
 # ruff

--- a/plugins/astral/skills/ty/SKILL.md
+++ b/plugins/astral/skills/ty/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ty
 description:
   Guide for using ty, the extremely fast Python type checker and language
   server. Use this when type checking Python code or setting up type checking in

--- a/plugins/astral/skills/ty/SKILL.md
+++ b/plugins/astral/skills/ty/SKILL.md
@@ -4,6 +4,8 @@ description:
   Guide for using ty, the extremely fast Python type checker and language
   server. Use this when type checking Python code or setting up type checking in
   Python projects.
+metadata:
+  author: astral-sh
 ---
 
 # ty

--- a/plugins/astral/skills/ty/SKILL.md
+++ b/plugins/astral/skills/ty/SKILL.md
@@ -6,6 +6,7 @@ description:
   Python projects.
 metadata:
   author: astral-sh
+  license: either of Apache-2.0 or MIT
 ---
 
 # ty

--- a/plugins/astral/skills/uv/SKILL.md
+++ b/plugins/astral/skills/uv/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: uv
 description:
   Guide for using uv, the Python package and project manager. Use this when
   working with Python projects, scripts, packages, or tools.

--- a/plugins/astral/skills/uv/SKILL.md
+++ b/plugins/astral/skills/uv/SKILL.md
@@ -5,6 +5,7 @@ description:
   working with Python projects, scripts, packages, or tools.
 metadata:
   author: astral-sh
+  license: either of Apache-2.0 or MIT
 ---
 
 # uv

--- a/plugins/astral/skills/uv/SKILL.md
+++ b/plugins/astral/skills/uv/SKILL.md
@@ -3,6 +3,8 @@ name: uv
 description:
   Guide for using uv, the Python package and project manager. Use this when
   working with Python projects, scripts, packages, or tools.
+metadata:
+  author: astral-sh
 ---
 
 # uv


### PR DESCRIPTION
Per the [Agent Skills specs](https://agentskills.io/specification#frontmatter-required), a `name` and a `description` field are both required in the frontmatter of a `SKILL.md` file. 

In Claude Code, it seems like the required `name` field is not being enforced, but after installing the skills in codex, I would get the following error:
```
⚠ Skipped loading 3 skill(s) due to invalid SKILL.md files.

⚠ /Users/kyrubeno/.codex/skills/ruff/SKILL.md: invalid YAML: missing field `name`

⚠ /Users/kyrubeno/.codex/skills/ty/SKILL.md: invalid YAML: missing field `name`

⚠ /Users/kyrubeno/.codex/skills/uv/SKILL.md: invalid YAML: missing field `name`
```
This was confirmed as well with the [`skills-ref validate` CLI](https://github.com/agentskills/agentskills/tree/main/skills-ref) (which itself is perhaps a good candidate to run in CI alongside the Prettier issue in #2)

```
 ❯ skills-ref validate /Users/kyrubeno/Developer/Personal/claude-code-plugins/plugins/astral/skills/uv
Validation failed for /Users/kyrubeno/Developer/Personal/claude-code-plugins/plugins/astral/skills/uv:
  - Missing required field in frontmatter: name
```

After the changes, the skills load without issue in Codex and pass the validator. I also added the optional author and license metadata which helped me distinguish this from a similarly named skill I had written myself before and a small correction to the CONTRIBUTING.md file. Per the specs the metadata fields should not be provided to the models so it's purely organizational. 