### PR TITLE
Use project-local ty for CC's LSP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ instruction to your `CLAUDE.md`:
 
 ### LSP
 
-The plugin also provides the ty LSP. It requires `uvx` to be available.
+The plugin also provides the ty LSP. It requires `ty` to be installed in your project:
+
+```bash
+uv add --dev ty
+```
 
 ## License
 

--- a/plugins/astral/.claude-plugin/plugin.json
+++ b/plugins/astral/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "astral",
   "description": "Skills for working with Python using Astral tools.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Astral",
     "url": "https://astral.sh"

--- a/plugins/astral/.claude-plugin/plugin.json
+++ b/plugins/astral/.claude-plugin/plugin.json
@@ -23,12 +23,15 @@
   ],
   "lspServers": {
     "ty": {
-      "command": "uvx",
-      "args": ["ty@latest", "server"],
+      "command": "uv",
+      "args": ["run", "ty", "server"],
       "extensionToLanguage": {
         ".py": "python",
-        ".pyi": "python"
-      }
+        ".pyi": "python",
+        ".pyw": "python"
+      },
+      "restartOnCrash": true,
+      "maxRestarts": 3
     }
   }
 }

--- a/plugins/astral/skills/ty/SKILL.md
+++ b/plugins/astral/skills/ty/SKILL.md
@@ -90,7 +90,7 @@ possibly-unresolved-reference = "warn"
 ## Language server
 
 This plugin automatically configures the ty language server for Python files
-(`.py` and `.pyi`).
+(`.py`, `.pyi`, and `.pyw`).
 
 ## Migrating from other tools
 


### PR DESCRIPTION
Switches from `uvx ty@latest server` to just `uv run ty server` so the LSP uses the version pinned in the project _rather than always fetching latest_. This keeps diagnostics consistent with what ty check actually reports locally.

Also adds .pyw (windows) to the supported extensions and sets restartOnCrash/maxRestarts for more reliable behavior.

verified that `claude plugin validate plugins/astral` passes.