### PR TITLE
fix: pin ty LSP server to ty==0.0.55

### DIFF
--- a/plugins/astral/.claude-plugin/plugin.json
+++ b/plugins/astral/.claude-plugin/plugin.json
@@ -24,7 +24,7 @@
   "lspServers": {
     "ty": {
       "command": "uvx",
-      "args": ["ty@latest", "server"],
+      "args": ["ty==0.0.55", "server"],
       "extensionToLanguage": {
         ".py": "python",
         ".pyi": "python"


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `ty@latest` in `lspServers` resolves to whatever is newest on PyPI at LSP-server startup time; a breaking or compromised release would auto-deploy to all plugin users.

**Evidence**: Confirmed `"args": ["ty@latest", "server"]` in `plugins/astral/.claude-plugin/plugin.json` line 27; current latest stable release is `ty==0.0.55` (astral-sh/ty).

**Fix**: Pins to `ty==0.0.55` so upgrades are explicit and controlled.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->